### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,6 +267,10 @@ exports.extract = function (cwd, opts) {
       if (win32) return next() // skip links on win for now before it can be tested
       xfs.unlink(name, function () {
         var srcpath = path.resolve(cwd, header.linkname)
+        if (header.linkname.indexOf('..') !== -1) {
+          console.log('skipping bad path', header.linkname);
+          return next();
+        }
 
         xfs.link(srcpath, name, function (err) {
           if (err && err.code === 'EPERM' && opts.hardlinkAsFilesFallback) {


### PR DESCRIPTION
Fixes [https://github.com/ghas-bootcamp-2024-11-13-cloudlabs653/ghas-bootcamp-javascript/security/code-scanning/1](https://github.com/ghas-bootcamp-2024-11-13-cloudlabs653/ghas-bootcamp-javascript/security/code-scanning/1)

To fix the problem, we need to ensure that the paths extracted from the archive do not contain any directory traversal elements like `..`. This can be done by validating the paths before using them in file system operations.

The best way to fix this without changing existing functionality is to add a validation step to check for directory traversal elements in `header.linkname` before using it to create `srcpath`. If the path is invalid, we should skip the entry or handle it appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
